### PR TITLE
Ensure we use exact match for version

### DIFF
--- a/src/registry.py
+++ b/src/registry.py
@@ -124,7 +124,7 @@ class Registry:
 
         response = self.s3.list_objects_v2(
             Bucket=self._bucket_name,
-            Prefix=f'{namespace}/{name}/{provider}/{version}/'
+            Prefix=f'{namespace}/{name}/{provider}/{version}.tar.gz'
         )
 
         if 'Contents' not in response:

--- a/src/registry.py
+++ b/src/registry.py
@@ -124,7 +124,7 @@ class Registry:
 
         response = self.s3.list_objects_v2(
             Bucket=self._bucket_name,
-            Prefix=f'{namespace}/{name}/{provider}/{version}'
+            Prefix=f'{namespace}/{name}/{provider}/{version}/'
         )
 
         if 'Contents' not in response:


### PR DESCRIPTION
E.g. if we had version `1.0.0` and `1.0.0-beta-1` then trying to download `1.0.0` downloads `1.0.0-beta-1`.